### PR TITLE
Change RAM length from 272K to 256K

### DIFF
--- a/website/lab/01/index.mdx
+++ b/website/lab/01/index.mdx
@@ -308,11 +308,8 @@ MEMORY
   FLASH (rx) : ORIGIN = 0x08000000, LENGTH = 512K
 
   /* On-chip SRAM (SRAM1+SRAM2+SRAM3 combined) */
-  RAM (rwx)  : ORIGIN = 0x20000000, LENGTH = 272K
+  RAM (rwx)  : ORIGIN = 0x20000000, LENGTH = 256K
 }
-
-/* Initial stack pointer: top of RAM */
-_estack = ORIGIN(RAM) + LENGTH(RAM);
 ```
 </TabItem>
 


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes the STM32U545RE-Q linker script by setting the correct RAM length. Without this, the firmware faults.

closes #654


### Testing Strategy

This pull request was tested by @alexandruradovici .


### TODO or Help Wanted

N/A


### Build

- [ ] Ran `./build.sh`.
- [ ] Ran `./website_build.sh`.

### Author

Signed-off-by: Alexandru Radovici <alexandru.radovici@wyliodrin.com>
